### PR TITLE
Logging unhandled exceptions as 500 errors

### DIFF
--- a/sandbox/App.Metrics.Sandbox/Controllers/ExceptionThrowingController.cs
+++ b/sandbox/App.Metrics.Sandbox/Controllers/ExceptionThrowingController.cs
@@ -1,0 +1,31 @@
+﻿using App.Metrics.Sandbox.JustForTesting;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace App.Metrics.Sandbox.Controllers
+{
+    [Route("api/[controller]")]
+    public class ExceptionThrowingController : Controller
+    {
+        private readonly IMetrics _metrics;
+
+        public ExceptionThrowingController(IMetrics metrics)
+        {
+            _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
+        }
+
+        [HttpGet]
+        public async Task<int> Get()
+        {
+            await Task.Run(() =>
+            {
+                throw new Exception();
+            });
+
+            return 0;
+        }
+    }
+}

--- a/sandbox/App.Metrics.Sandbox/JustForTesting/SampleRequests.cs
+++ b/sandbox/App.Metrics.Sandbox/JustForTesting/SampleRequests.cs
@@ -10,16 +10,16 @@ namespace App.Metrics.Sandbox.JustForTesting
 {
     public static class SampleRequests
     {
-        private static readonly Uri ApiBaseAddress = new Uri("http://localhost:1111/");        
+        private static readonly Uri ApiBaseAddress = new Uri("http://localhost:2222/");
 
         public static void Run(CancellationToken token)
         {
             var randomBufferGenerator = new RandomBufferGenerator(50000);
             var scheduler = new DefaultTaskScheduler();
             var httpClient = new HttpClient
-                             {
-                                 BaseAddress = ApiBaseAddress
-                             };
+            {
+                BaseAddress = ApiBaseAddress
+            };
 
             Task.Run(
                 () => scheduler.Interval(
@@ -42,7 +42,10 @@ namespace App.Metrics.Sandbox.JustForTesting
                     TaskCreationOptions.None,
                     async () =>
                     {
-                        await httpClient.GetAsync("api/randomstatuscode", token);                        
+                        var randomStatusCode = httpClient.GetAsync("api/randomstatuscode", token);
+                        var exceptionThrower = httpClient.GetAsync("api/exceptionThrowing", token);
+
+                        await Task.WhenAll(randomStatusCode, exceptionThrower);
                     },
                     token),
                 token);


### PR DESCRIPTION
This change adds a try catch around the middleware so that we catch unhandled exceptions and log them as 500 internal server errors.