### PR TITLE
Re-throw exception after we set status code as 500

### DIFF
--- a/src/App.Metrics.Extensions.Middleware/ErrorRequestMeterMiddleware.cs
+++ b/src/App.Metrics.Extensions.Middleware/ErrorRequestMeterMiddleware.cs
@@ -51,6 +51,7 @@ namespace App.Metrics.Extensions.Middleware
             catch
             {
                 context.Response.StatusCode = 500;
+                throw;
             }
             finally
             {


### PR DESCRIPTION
This change should log 500 errors as well as re-throwing the original exception
