### PR TITLE
Reference Microsoft.Extensions.Logging.Abstractions instead of full Logging package

### DIFF
--- a/benchmarks/App.Metrics.Benchmarks/App.Metrics.Benchmarks.csproj
+++ b/benchmarks/App.Metrics.Benchmarks/App.Metrics.Benchmarks.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.10.3" />
     <PackageReference Include="BenchmarkDotNet.Core" Version="0.10.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/App.Metrics/App.Metrics.csproj
+++ b/src/App.Metrics/App.Metrics.csproj
@@ -37,7 +37,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />    
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />

--- a/test/App.Metrics.Facts/App.Metrics.Facts.csproj
+++ b/test/App.Metrics.Facts/App.Metrics.Facts.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="Moq" Version="4.7.1" />
     <PackageReference Include="xunit" Version="2.2.0" />


### PR DESCRIPTION
### The issue or feature being addressed

I like to use App.Metrics in one of my libraries but I don't want to have Microsoft.Extensions.Logging in my dependency tree.

Libraries should only depend on `Microsoft.Extensions.Logging.Abstractions` which contains the necessary interfaces for creating log entries (ILoggerFactory, ILogger, etc). `Microsoft.Extensions.Logging` is Microsoft's *implementation* and should only be referenced by applications.

PS: I hope it's ok to not create a separate issue for this... I'll create it if you want it.

### Details on the issue fix or feature implementation

App.Metrics now references the Abstractions package; the test-projects reference the actual Logging package (because they need to call `AddLogging()`).

NOTE: Technically, this is a "breaking change" because *applications* who use your library and don't have a reference to `Microsoft.Extensions.Logging` would now get a compilation error. The package is in the template though, so this shouldn't be an issue IMO.

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [ ] I have included the github issue number in my commits 