### PR TITLE
Build Script: Restore the whole solution; build the whole solution on windows

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -108,25 +108,24 @@ Task("Restore")
         Sources = new [] { "https://api.nuget.org/v3/index.json", "https://www.myget.org/F/alhardy/api/v3/index.json" }
     };
 
-	var projects = solution.GetProjects();
-
-	foreach(var project in projects)
-	{
-	    DotNetCoreRestore(project.Path.ToString(), settings);
-    }    
+	DotNetCoreRestore(solutionFile, settings);
 });
 
 Task("Build")    
     .IsDependentOn("Restore")
     .Does(() =>
 {	
-	var projects = solution.GetProjects();
-    
 	var settings = new DotNetCoreBuildSettings  { Configuration = configuration };
 
-    foreach(var project in projects)
-    {		
-		if (!IsRunningOnWindows())
+	if (IsRunningOnWindows())
+	{
+		DotNetCoreBuild(solutionFile, settings);
+	}
+	else
+	{
+		var projects = solution.GetProjects();
+
+		foreach(var project in projects)
         {
 			// Ignore Net452 on non-windows environments
 			if (project.Path.ToString().Contains("Net452"))
@@ -146,10 +145,11 @@ Task("Build")
 			}
 
 			Context.Information("Building as " + settings.Framework + ": " +  project.Path.ToString());
-        }	 
 
-        DotNetCoreBuild(project.Path.ToString(), settings);
-    }    
+			DotNetCoreBuild(project.Path.ToString(), settings);
+		}
+
+	}
 });
 
 Task("Pack")


### PR DESCRIPTION
### The issue or feature being addressed

The build script is extremely slow because every project is restored and built separately. The new dotnet cli supports restoring and building a *.sln.

### Details on the issue fix or feature implementation

* dotnet restore is just called once for the whole solution
* dotnet build is just called once for the whole solution on windows. Non-Windows still uses the old logic due to the multi-targeting issue.

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [ ] I have included the github issue number in my commits 