### PR TITLE
#123 config tests fail for cultures with different number formats

### DIFF
--- a/test/App.Metrics.Extensions.Middleware.Integration.Facts/DependencyInjection/TestConfiguration/appsettings.json
+++ b/test/App.Metrics.Extensions.Middleware.Integration.Facts/DependencyInjection/TestConfiguration/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
   "AspNetMetrics": {
     "ApdexTrackingEnabled": false,
-    "ApdexTSeconds": 0.8,
+    "ApdexTSeconds": "0.8",
     "HealthEndpointEnabled": false,
     "MetricsEndpointEnabled": false,
     "MetricsTextEndpointEnabled": false,


### PR DESCRIPTION
### The issue or feature being addressed

#123

### Details on the issue fix or feature implementation

A simple workaround.

This should probably be reverted when the bug is fixed. However, it seems like this will not be before ASP.NET Core 2.0

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits 