### PR TITLE
#172 Add degradedOnError param to all health check extensions methods

### DIFF
--- a/test/App.Metrics.Facts/Health/HealthCheckFactoryExtensionsTests.cs
+++ b/test/App.Metrics.Facts/Health/HealthCheckFactoryExtensionsTests.cs
@@ -18,86 +18,101 @@ namespace App.Metrics.Facts.Health
 
         public HealthCheckFactoryExtensionsTests() { _logger = new LoggerFactory().CreateLogger<HealthCheckFactory>(); }
 
-        [Fact]
+        [Theory]
         [Trait("Category", "Requires Connectivity")]
-        public async Task can_execute_http_get_check()
+        [InlineData(HealthCheckStatus.Healthy, "https://github.com")]
+        [InlineData(HealthCheckStatus.Degraded, "https://github.unknown", true)]
+        [InlineData(HealthCheckStatus.Unhealthy, "https://github.unknown", false)]
+        public async Task can_execute_http_get_check(HealthCheckStatus expectedResult, string uriString, bool degradedOnError = false)
         {
             var healthChecks = Enumerable.Empty<HealthCheck>();
             var name = "github home";
 
-            var factory = new HealthCheckFactory(_logger, new Lazy<IMetrics>(),  healthChecks);
+            var factory = new HealthCheckFactory(_logger, new Lazy<IMetrics>(), healthChecks);
 
-            factory.RegisterHttpGetHealthCheck(name, new Uri("https://github.com"), TimeSpan.FromSeconds(10));
+            factory.RegisterHttpGetHealthCheck(name, new Uri(uriString), TimeSpan.FromSeconds(5), degradedOnError: degradedOnError);
 
             var check = factory.Checks.FirstOrDefault();
             var result = await check.Value.ExecuteAsync().ConfigureAwait(false);
 
-            result.Check.Status.Should().Be(HealthCheckStatus.Healthy);
+            result.Check.Status.Should().Be(expectedResult);
         }
 
-        [Fact(Skip = "Mock HTTP Call")]
+        [Theory(Skip = "Mock HTTP Call")]
         [Trait("Category", "Requires Connectivity")]
-        public async Task can_execute_ping_check()
+        [InlineData(HealthCheckStatus.Healthy, "github.com")]
+        [InlineData(HealthCheckStatus.Degraded, "github.unknown", true)]
+        [InlineData(HealthCheckStatus.Unhealthy, "github.unknown", false)]
+        public async Task can_execute_ping_check(HealthCheckStatus expectedResult, string host, bool degradedOnError = false)
         {
             var healthChecks = Enumerable.Empty<HealthCheck>();
             var name = "github ping";
 
             var factory = new HealthCheckFactory(_logger, new Lazy<IMetrics>(), healthChecks);
 
-            factory.RegisterPingHealthCheck(name, "github.com", TimeSpan.FromSeconds(10));
+            factory.RegisterPingHealthCheck(name, host, TimeSpan.FromSeconds(5), degradedOnError: degradedOnError);
 
             var check = factory.Checks.FirstOrDefault();
             var result = await check.Value.ExecuteAsync().ConfigureAwait(false);
 
-            result.Check.Status.Should().Be(HealthCheckStatus.Healthy);
+            result.Check.Status.Should().Be(expectedResult);
         }
 
-        [Fact]
-        public async Task can_execute_process_physical_memory_check()
+        [Theory]
+        [InlineData(HealthCheckStatus.Healthy, int.MaxValue)]
+        [InlineData(HealthCheckStatus.Degraded, int.MinValue, true)]
+        [InlineData(HealthCheckStatus.Unhealthy, int.MinValue, false)]
+        public async Task can_execute_process_physical_memory_check(HealthCheckStatus expectedResult, long thresholdBytes, bool degradedOnError = false)
         {
             var healthChecks = Enumerable.Empty<HealthCheck>();
             var name = "physical memory";
 
             var factory = new HealthCheckFactory(_logger, new Lazy<IMetrics>(), healthChecks);
 
-            factory.RegisterProcessPhysicalMemoryHealthCheck(name, int.MaxValue);
+            factory.RegisterProcessPhysicalMemoryHealthCheck(name, thresholdBytes, degradedOnError);
 
             var check = factory.Checks.FirstOrDefault();
             var result = await check.Value.ExecuteAsync().ConfigureAwait(false);
 
-            result.Check.Status.Should().Be(HealthCheckStatus.Healthy);
+            result.Check.Status.Should().Be(expectedResult);
         }
 
-        [Fact]
-        public async Task can_execute_process_private_memory_check()
+        [Theory]
+        [InlineData(HealthCheckStatus.Healthy, int.MaxValue)]
+        [InlineData(HealthCheckStatus.Degraded, int.MinValue, true)]
+        [InlineData(HealthCheckStatus.Unhealthy, int.MinValue, false)]
+        public async Task can_execute_process_private_memory_check(HealthCheckStatus expectedResult, long thresholdBytes, bool degradedOnError = false)
         {
             var healthChecks = Enumerable.Empty<HealthCheck>();
             var name = "private memory";
 
             var factory = new HealthCheckFactory(_logger, new Lazy<IMetrics>(), healthChecks);
 
-            factory.RegisterProcessPrivateMemorySizeHealthCheck(name, int.MaxValue);
+            factory.RegisterProcessPrivateMemorySizeHealthCheck(name, thresholdBytes, degradedOnError);
 
             var check = factory.Checks.FirstOrDefault();
             var result = await check.Value.ExecuteAsync().ConfigureAwait(false);
 
-            result.Check.Status.Should().Be(HealthCheckStatus.Healthy);
+            result.Check.Status.Should().Be(expectedResult);
         }
 
-        [Fact]
-        public async Task can_execute_process_virtual_memory_check()
+        [Theory]
+        [InlineData(HealthCheckStatus.Healthy, long.MaxValue)]
+        [InlineData(HealthCheckStatus.Degraded, long.MinValue, true)]
+        [InlineData(HealthCheckStatus.Unhealthy, long.MinValue, false)]
+        public async Task can_execute_process_virtual_memory_check(HealthCheckStatus expectedResult, long thresholdBytes, bool degradedOnError = false)
         {
             var healthChecks = Enumerable.Empty<HealthCheck>();
             var name = "virtual memory";
 
             var factory = new HealthCheckFactory(_logger, new Lazy<IMetrics>(), healthChecks);
 
-            factory.RegisterProcessVirtualMemorySizeHealthCheck(name, long.MaxValue);
+            factory.RegisterProcessVirtualMemorySizeHealthCheck(name, thresholdBytes, degradedOnError);
 
             var check = factory.Checks.FirstOrDefault();
             var result = await check.Value.ExecuteAsync().ConfigureAwait(false);
 
-            result.Check.Status.Should().Be(HealthCheckStatus.Healthy);
+            result.Check.Status.Should().Be(expectedResult);
         }
 
         [Fact]


### PR DESCRIPTION
### The issue or feature being addressed

#172 

### Details on the issue fix or feature implementation

Add an optional boolean parameter (degradedOnError) to all the health check extension methods of the class `HealthCheckFactoryExtensions`.
Thus when a health check fails we can not only return an **Unhealthy** status but also a **Degraded** one.

I also unit tested all extensions methods of the class for **Unhealthy** and **Degraded** status.

### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [x] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits 